### PR TITLE
Add title tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,5 +11,11 @@
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     
+    {%- unless include.title contains "Kopernicus Wiki" -%}
+    <title>{{ include.title }} - Kopernicus Wiki</title>
+    {%- else -%}
+    <title>{{ include.title }}</title>
+    {%- endunless -%}
+    
     {%- feed_meta -%}
   </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
-  {%- include head.html -%}
+  {%- include head.html title=page.title -%}
 
   <body>
 


### PR DESCRIPTION
No longer will the title of the webpage be just the url!

By passing in page.title to the head.html _includes file, we can display the page title in the tab title. An additional check ensures that "Kopernicus Wiki" is not duplicated - for instance, on the home page; otherwise, " - Kopernicus Wiki" is appended to the page title in the tab title.