### PR TITLE
Add documentation for all scaled space materials

### DIFF
--- a/docs/Syntax/Material/Scaled/Atmospheric.md
+++ b/docs/Syntax/Material/Scaled/Atmospheric.md
@@ -1,0 +1,112 @@
+# Atmospheric Material
+
+**Shader:** `Terrain/Scaled Planet (RimAerial)`
+
+The Atmospheric `Material { }` drives the `Terrain/Scaled Planet (RimAerial)` shader — the scaled-space planet shader for bodies that have an atmosphere. It paints the planet's distant, low-LOD sphere from a single **colour map**, lights it with a standard Blinn-Phong specular model, and then adds one ingredient the airless planet shaders lack: a **view-angle rim glow** around the planet's limb that stands in for the soft halo of an atmosphere seen edge-on (the "aerial perspective").
+
+In the stock [KittopiaTech dumps](https://github.com/Kopernicus/kittopia-dumps), the bodies set to `type = Atmospheric` are Eve, Duna, and Laythe. (Jool is listed as `Atmospheric` in the dumps as well, but in the live game it actually ships with the [Gas Giant material](/Syntax/Material/Scaled/GasGiant) — one of the few places the dumps diverge from the running game.) Kerbin and Eeloo instead use the closely related `AtmosphericStandard` type (the `Terrain/Scaled Planet (RimAerial) Standard` shader), which shares the same rim concept but lights the surface through Unity's Standard PBR model.
+
+If your body has no atmosphere, use the plainer [Vacuum material](/Syntax/Material/Scaled/Vacuum) instead — it is identical but for the missing rim. If you want a procedurally-banded gas giant rather than a painted surface, see the [Gas Giant material](/Syntax/Material/Scaled/GasGiant), which has its own, brighter rim model.
+
+We shall first see how to enable the material, then how the shader lights the surface and draws the rim, and finally discuss each group of properties in turn.
+
+## Enabling
+
+Select the atmospheric material by setting `type = Atmospheric` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+
+```
+ScaledVersion
+{
+    type = Atmospheric
+    Material
+    {
+        // Surface maps
+        texture = MyMod/PluginData/Laythe_color.dds
+        normals = MyMod/PluginData/Laythe_normal.dds
+
+        // Colour and specular response
+        color     = 1, 1, 1, 1
+        specColor = 0.5, 0.5, 0.5, 1
+        shininess = 0.078125
+
+        // Atmospheric rim
+        rimPower     = 3
+        rimBlend     = 1
+        rimColorRamp = MyMod/PluginData/Laythe_rim.dds
+
+        // Resource-scanner overlay (optional)
+        resourceMap = MyMod/PluginData/Laythe_resources.dds
+    }
+}
+```
+
+## How the surface is lit
+
+The shader is essentially Unity's BumpedSpecular (Blinn-Phong) lighting with three KSP-specific pieces layered on top — two that build the lit surface, and one that paints the atmosphere:
+
+1. **Colour and gloss** — `texture` is the colour map. Its **RGB** channels are the surface albedo (multiplied by `color`), and its **alpha** channel is a per-pixel *specular intensity mask*: bright areas catch the sun's highlight strongly, dark areas stay matte. This lets a single texture vary glossiness across the surface (e.g. shiny seas against dull land).
+2. **Surface relief** — `normals` is a tangent-space normal map that perturbs the lighting per pixel, so the body keeps fine surface detail when viewed from orbit even though the scaled-space mesh is smooth.
+3. **Atmospheric rim** — a glow that fades in toward the planet's silhouette. Where the surface faces the camera head-on it contributes nothing; as the surface curves away toward the limb it brightens, reaching full strength right at the edge (`rimFalloff = (1 − N·V)^rimPower`). `rimPower` controls how tightly the glow hugs the limb and `rimBlend` scales its overall brightness. Its colour is read from `rimColorRamp`, a 1-D ramp **indexed by the day/night terminator**, so the sunlit limb and the dark-side limb can be tinted differently (a bright blue dayside haze fading to a dim nightside edge, say). The finished rim is then scaled by `opacity`.
+
+The highlight itself is shaped by `specColor` (its tint) and `shininess` (how tight it is); setting `specColor` to black drops the specular entirely. There is no emission term beyond the rim — what you paint is what you get, lit by the local star.
+
+A `resourceMap` overlay shares the rim's emission slot: the scanner colour is composited as `lerp(rim, resourceRGB, resourceAlpha)`, so where the resource map is opaque it replaces the rim glow at that point, and where it is transparent the rim shows through untouched. The lit surface beneath is always added on top, so the overlay never hides the planet itself. The default all-black map contributes nothing.
+
+## Properties
+
+The properties fall into five groups, which we shall take in turn:
+
+1. **Surface maps** — the colour and normal textures that define the body's appearance.
+2. **Colour and specular** — the tints and highlight sharpness applied during lighting.
+3. **Atmospheric rim** — the view-angle halo and the ramp that colours it.
+4. **Resource overlay** — the optional scanner map composited on top.
+5. **Opacity** — the rim fade scalar.
+
+### Surface maps
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `texture` | File Path | The scaled-space colour map. **RGB** = surface albedo (multiplied by `color`); **alpha** = per-pixel specular intensity mask. Also accepts the alias `mainTex`. Default "white". |
+| `mainTexScale` / `mainTexOffset` | Vector2 | Tiling and offset of the colour map. |
+| `normals` | File Path | Tangent-space normal map, stored in DXT5nm packing (X in the alpha channel, Y in green, Z reconstructed). Also accepts the alias `bumpMap`. Default "bump" (flat). |
+| `bumpMapScale` / `bumpMapOffset` | Vector2 | Tiling and offset of the normal map. |
+
+### Colour and specular
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `color` | Color | Master diffuse tint multiplied into the colour map's RGB before lighting. The alpha is unused. Default (1, 1, 1, 1). |
+| `specColor` | Color | Specular highlight tint, scaled by the star's light colour and further modulated by the colour map's alpha mask. Set to black to disable specular entirely. Default (0.5, 0.5, 0.5, 1). |
+| `shininess` | Decimal | Highlight sharpness. The value maps to a Blinn-Phong specular exponent of `shininess × 128` — smaller values give a broad, soft highlight, larger values a tight, sharp one. The shader declares the valid range as `[0.03, 1]`. Default 0.078125. |
+
+### Atmospheric rim
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `rimPower` | Decimal | View-angle rim falloff exponent. Larger values concentrate the glow into a thinner ring at the limb; smaller values spread it across a broader band. Default 3. |
+| `rimBlend` | Decimal | Master brightness multiplier on the sampled rim colour, applied before the `opacity` fade. Set to 0 to suppress the rim entirely. Default 1. |
+| `rimColorRamp` | File Path | 1-D colour ramp that tints the rim, indexed across the day/night terminator so the lit and dark limbs can be coloured differently. Default "white". |
+| `rimColorRampScale` / `rimColorRampOffset` | Vector2 | Tiling and offset of the rim colour ramp. |
+| `Gradient` | Gradient | The `rimColorRamp`, but defined explicitly as a gradient instead of a texture. Each entry's left value is the position along the terminator from 0 (lit side) to 1 (dark side), and the right value is the rim colour there. |
+| `localLightDirection` | Vector4 | Object-space sun direction used to compute the terminator coordinate for the ramp. Marked `[PerRendererData]` and overwritten every frame by KSP's scaled-space lighting controller, so a config value has no lasting effect. Default (1, 0, 0, 0). |
+
+### Resource overlay
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `resourceMap` | File Path | Resource-scanner overlay texture. Composited into the emission as `lerp(rim, resourceRGB, resourceAlpha)`: opaque pixels replace the rim glow, transparent pixels leave it alone. Default "black" (contributes nothing). |
+| `resourceMapScale` / `resourceMapOffset` | Vector2 | Tiling and offset of the resource map. |
+
+### Opacity
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `opacity` | Decimal | Master strength of the rim **emission**, range `[0, 1]`. It scales the rim glow only — not the lit surface (which always renders opaque), nor the resource overlay (which composites at full strength regardless). Default 1. |
+
+## Notes
+
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
+* `localLightDirection` is likewise `[PerRendererData]` and rewritten each frame, so although the loader exposes it as a config field, setting it has no lasting effect — it exists so KSP can keep the rim ramp tracking the real Sun as the planet rotates and orbits.
+* The rim's view-angle term uses the body's smooth **geometric** normal, not the normal-mapped surface normal — so surface relief shapes the lit surface and specular highlight, but not the limb glow.
+* The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.
+* If the shader fails to compile on the target platform it falls back to Unity's `Standard` shader.

--- a/docs/Syntax/Material/Scaled/Atmospheric.md
+++ b/docs/Syntax/Material/Scaled/Atmospheric.md
@@ -12,7 +12,7 @@ We shall first see how to enable the material, then how the shader lights the su
 
 ## Enabling
 
-Select the atmospheric material by setting `type = Atmospheric` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+Select the atmospheric material by setting `type = Atmospheric` in the [`ScaledVersion { }`](/Syntax/ScaledVersion/) node. The `Material { }` node then accepts the properties listed below.
 
 ```
 ScaledVersion
@@ -105,7 +105,7 @@ The properties fall into five groups, which we shall take in turn:
 
 ## Notes
 
-* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion/) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
 * `localLightDirection` is likewise `[PerRendererData]` and rewritten each frame, so although the loader exposes it as a config field, setting it has no lasting effect — it exists so KSP can keep the rim ramp tracking the real Sun as the planet rotates and orbits.
 * The rim's view-angle term uses the body's smooth **geometric** normal, not the normal-mapped surface normal — so surface relief shapes the lit surface and specular highlight, but not the limb glow.
 * The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.

--- a/docs/Syntax/Material/Scaled/AtmosphericStandard.md
+++ b/docs/Syntax/Material/Scaled/AtmosphericStandard.md
@@ -1,0 +1,114 @@
+# AtmosphericStandard Material
+
+**Shader:** `Terrain/Scaled Planet (RimAerial) Standard`
+
+The AtmosphericStandard `Material { }` drives the `Terrain/Scaled Planet (RimAerial) Standard` shader — the scaled-space planet shader for atmospheric bodies, lit with Unity's **Standard** physically-based shading model. Like the plainer [Atmospheric material](/Syntax/Material/Scaled/Atmospheric) it paints the planet's distant, low-LOD sphere from a single **colour map** and rings the limb with a **view-angle rim glow** that stands in for the soft halo of an atmosphere seen edge-on (the "aerial perspective"). The two materials accept exactly the same properties and draw the same rim; what differs is how the surface itself is shaded — here it is energy-conserving PBR specular, with image-based ambient and reflections supplied by Unity, rather than the older hand-rolled Blinn-Phong highlight.
+
+In the stock system this material is used by Kerbin and Eeloo. (Eeloo has no atmosphere of its own, yet is still assigned this type; a body that wants no visible halo simply leaves its rim dark — see `rimBlend` and `rimColorRamp` below.)
+
+If your body has no atmosphere, you can also use the plainer [Vacuum material](/Syntax/Material/Scaled/Vacuum) — it builds the surface the same way but has no rim at all. If you want a procedurally-banded gas giant rather than a painted surface, see the [Gas Giant material](/Syntax/Material/Scaled/GasGiant), which has its own, brighter rim model.
+
+> The Standard scaled-planet shaders ship only with **KSP 1.9 and later**. On older KSP versions this type is unavailable; use [`type = Atmospheric`](/Syntax/Material/Scaled/Atmospheric) instead.
+
+We shall first see how to enable the material, then how the shader lights the surface and draws the rim, and finally discuss each group of properties in turn.
+
+## Enabling
+
+Select the material by setting `type = AtmosphericStandard` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+
+```
+ScaledVersion
+{
+    type = AtmosphericStandard
+    Material
+    {
+        // Surface maps
+        texture = MyMod/PluginData/Kerbin_color.dds
+        normals = MyMod/PluginData/Kerbin_normal.dds
+
+        // Colour and specular response
+        color     = 1, 1, 1, 1
+        specColor = 0.5, 0.5, 0.5, 1
+        shininess = 0.078125
+
+        // Atmospheric rim
+        rimPower     = 3
+        rimBlend     = 1
+        rimColorRamp = MyMod/PluginData/Kerbin_rim.dds
+
+        // Resource-scanner overlay (optional)
+        resourceMap = MyMod/PluginData/Kerbin_resources.dds
+    }
+}
+```
+
+## How the surface is lit
+
+The shader is a Unity **Standard (specular workflow)** surface shader with two KSP-specific pieces layered on top — one that adds surface relief, and one that paints the atmosphere. Because it is a true PBR model, the engine also supplies spherical-harmonic ambient, reflection probes, and proper energy conservation for free, rather than the single hand-rolled highlight of the legacy shaders:
+
+1. **Albedo and smoothness** — `texture` is the colour map. Its **RGB** channels are the surface albedo (multiplied by `color`), and its **alpha** channel is a per-pixel *smoothness* mask: bright areas read as glossy, dark areas as rough and matte. The global `shininess` value scales that alpha, so the final per-pixel smoothness is `texture.alpha × shininess`. This lets a single texture vary glossiness across the surface (e.g. shiny seas against dull land).
+2. **Surface relief** — `normals` is a tangent-space normal map that perturbs the lighting per pixel, so the body keeps fine surface detail when viewed from orbit even though the scaled-space mesh is smooth.
+3. **Atmospheric rim** — a glow that fades in toward the planet's silhouette. Where the surface faces the camera head-on it contributes nothing; as the surface curves away toward the limb it brightens, reaching full strength right at the edge (`rimFalloff = (1 − N·V)^rimPower`). `rimPower` controls how tightly the glow hugs the limb and `rimBlend` scales its overall brightness. Its colour is read from `rimColorRamp`, a 1-D ramp **indexed by the day/night terminator**, so the sunlit limb and the dark-side limb can be tinted differently (a bright blue dayside haze fading to a dim nightside edge, say). The finished rim is then scaled by `opacity`.
+
+Because this is a physically-based specular workflow, `specColor` is the surface's **specular reflectance at normal incidence** (its F0 colour) rather than a free-floating highlight tint — Unity uses it, together with the smoothness above, to drive both the direct specular highlight and the image-based reflections and ambient that the Standard model adds. Setting `specColor` to black removes the specular reflection entirely. There is no emission term beyond the rim — what you paint is what you get, lit by the local star and its surroundings.
+
+A `resourceMap` overlay shares the rim's emission slot: the scanner colour is composited as `lerp(rim, resourceRGB, resourceAlpha)`, so where the resource map is opaque it replaces the rim glow at that point, and where it is transparent the rim shows through untouched. The lit surface beneath is always added on top, so the overlay never hides the planet itself. The default all-black map contributes nothing.
+
+## Properties
+
+The properties fall into five groups, which we shall take in turn:
+
+1. **Surface maps** — the colour and normal textures that define the body's appearance.
+2. **Colour and specular** — the tints and surface smoothness applied during PBR lighting.
+3. **Atmospheric rim** — the view-angle halo and the ramp that colours it.
+4. **Resource overlay** — the optional scanner map composited on top.
+5. **Opacity** — the rim fade scalar.
+
+### Surface maps
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `texture` | File Path | The scaled-space colour map. **RGB** = surface albedo (multiplied by `color`); **alpha** = per-pixel smoothness mask (scaled by `shininess`). Also accepts the alias `mainTex`. Default "white". |
+| `mainTexScale` / `mainTexOffset` | Vector2 | Tiling and offset of the colour map. |
+| `normals` | File Path | Tangent-space normal map, stored in DXT5nm packing (X in the alpha channel, Y in green, Z reconstructed). Also accepts the alias `bumpMap`. Default "bump" (flat). |
+| `bumpMapScale` / `bumpMapOffset` | Vector2 | Tiling and offset of the normal map. |
+
+### Colour and specular
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `color` | Color | Master diffuse tint multiplied into the colour map's RGB before lighting. The alpha is unused. Default (1, 1, 1, 1). |
+| `specColor` | Color | Specular reflectance at normal incidence (the PBR **F0** colour), used together with the surface smoothness to drive both the direct highlight and the image-based reflections. Set to black to remove specular reflection entirely. Default (0.5, 0.5, 0.5, 1). |
+| `shininess` | Decimal | Global smoothness scale. The final per-pixel smoothness is `texture.alpha × shininess`, so `1` passes the texture's gloss mask through unchanged and lower values make the whole surface rougher and more matte. The shader declares the valid range as `[0.03, 1]`. Default 0.078125. |
+
+### Atmospheric rim
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `rimPower` | Decimal | View-angle rim falloff exponent. Larger values concentrate the glow into a thinner ring at the limb; smaller values spread it across a broader band. Default 3. |
+| `rimBlend` | Decimal | Master brightness multiplier on the sampled rim colour, applied before the `opacity` fade. Set to 0 to suppress the rim entirely. Default 1. |
+| `rimColorRamp` | File Path | 1-D colour ramp that tints the rim, indexed across the day/night terminator so the lit and dark limbs can be coloured differently. Default "white". |
+| `rimColorRampScale` / `rimColorRampOffset` | Vector2 | Tiling and offset of the rim colour ramp. |
+| `Gradient` | Gradient | The `rimColorRamp`, but defined explicitly as a gradient instead of a texture. Each entry's left value is the position along the terminator from 0 (lit side) to 1 (dark side), and the right value is the rim colour there. |
+| `localLightDirection` | Vector4 | Object-space sun direction used to compute the terminator coordinate for the ramp. Marked `[PerRendererData]` and overwritten every frame by KSP's scaled-space lighting controller, so a config value has no lasting effect. Default (1, 0, 0, 0). |
+
+### Resource overlay
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `resourceMap` | File Path | Resource-scanner overlay texture. Composited into the emission as `lerp(rim, resourceRGB, resourceAlpha)`: opaque pixels replace the rim glow, transparent pixels leave it alone. Default "black" (contributes nothing). |
+| `resourceMapScale` / `resourceMapOffset` | Vector2 | Tiling and offset of the resource map. |
+
+### Opacity
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `opacity` | Decimal | Master strength of the rim **emission**, range `[0, 1]`. It scales the rim glow only — not the lit surface (which always renders opaque), nor the resource overlay (which composites at full strength regardless). Default 1. |
+
+## Notes
+
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
+* `localLightDirection` is likewise `[PerRendererData]` and rewritten each frame, so although the loader exposes it as a config field, setting it has no lasting effect — it exists so KSP can keep the rim ramp tracking the real Sun as the planet rotates and orbits.
+* Unlike the plain [Atmospheric](/Syntax/Material/Scaled/Atmospheric) shader, whose rim is keyed to the body's smooth **geometric** normal, this build computes the rim's view-angle term against the **normal-mapped** surface normal — so surface relief feeds the limb glow as well as the lit surface, though the effect is subtle at the grazing angles where the rim is brightest.
+* The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.
+* The shader has no shadow-casting pass of its own; it delegates shadow casting to its `Standard` fallback (which also takes over wholesale if the shader fails to compile). It supports only Unity's modern single-pass deferred path, not the legacy two-step prepass — invisible to config authors, but the reason the lit result matches across rendering paths.

--- a/docs/Syntax/Material/Scaled/AtmosphericStandard.md
+++ b/docs/Syntax/Material/Scaled/AtmosphericStandard.md
@@ -14,7 +14,7 @@ We shall first see how to enable the material, then how the shader lights the su
 
 ## Enabling
 
-Select the material by setting `type = AtmosphericStandard` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+Select the material by setting `type = AtmosphericStandard` in the [`ScaledVersion { }`](/Syntax/ScaledVersion/) node. The `Material { }` node then accepts the properties listed below.
 
 ```
 ScaledVersion
@@ -107,7 +107,7 @@ The properties fall into five groups, which we shall take in turn:
 
 ## Notes
 
-* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which Kopernicus attaches to every non-star body with its `floatName` bound to `_Opacity`. As the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion/) altitudes the fader sweeps this value, fading the atmospheric halo with the transition. A static config value is therefore normally left at its default of 1.
 * `localLightDirection` is likewise `[PerRendererData]` and rewritten each frame, so although the loader exposes it as a config field, setting it has no lasting effect — it exists so KSP can keep the rim ramp tracking the real Sun as the planet rotates and orbits.
 * Unlike the plain [Atmospheric](/Syntax/Material/Scaled/Atmospheric) shader, whose rim is keyed to the body's smooth **geometric** normal, this build computes the rim's view-angle term against the **normal-mapped** surface normal — so surface relief feeds the limb glow as well as the lit surface, though the effect is subtle at the grazing angles where the rim is brightest.
 * The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.

--- a/docs/Syntax/Material/Scaled/GasGiant.md
+++ b/docs/Syntax/Material/Scaled/GasGiant.md
@@ -1,0 +1,170 @@
+# Gas Giant Material
+
+**Shader:** `Terrain/Gas Giant` &nbsp;·&nbsp; **Runtime component:** `GasGiantMaterialControls`
+
+The Gas Giant `Material { }` drives the `Terrain/Gas Giant` shader — the animated, banded scaled-space surface used by Jool. Unlike the [Vacuum/Atmospheric materials](/Syntax/ScaledVersion/Material), which paint the planet from a single colour map, the gas giant builds its appearance procedurally from two **swirling cloud band layers**:
+
+* A **far (base) layer** that defines the overall banding and is visible at any distance.
+* A **detail (near) layer** of higher-frequency cloud structure that fades in as the camera approaches.
+
+The bands scroll and swirl over time. We shall first see how to enable the material, then walk through how those two layers are assembled, and finally discuss each group of properties in turn.
+
+> If you would rather have gas giants generated for you than author every map by hand, see [Procedural Gas Giants](/Syntax/Expansion/ProceduralGasGiants).
+
+## Enabling
+
+Select the gas giant material by setting `type = GasGiant` in the [`ScaledVersion { }`](/Syntax/ScaledVersion/Material) node. The `Material { }` node then accepts the properties listed below.
+
+```
+ScaledVersion
+{
+    type = GasGiant
+    Material
+    {
+        // Far (base) band layer
+        cloudPatternMap = MyMod/PluginData/Jool_pattern.dds
+        colorMap        = MyMod/PluginData/Jool_ramp1.dds
+        colorMap2       = MyMod/PluginData/Jool_ramp2.dds
+        normalMap       = MyMod/PluginData/Jool_normal.dds
+
+        // Detail (near) band layer
+        detailCloudPatternMap = MyMod/PluginData/Jool_detail_pattern.dds
+        detailColorMap        = MyMod/PluginData/Jool_detail_ramp.dds
+        detailNormalMap       = MyMod/PluginData/Jool_detail_normal.dds
+        detailTiling          = 10
+
+        // Detail fade by camera distance
+        nearDetailDistance = 50
+        nearDetailStrength = 0.8
+        farDetailDistance  = 200
+        farDetailStrength  = 0
+
+        // Animation control maps
+        movementControlTexture = MyMod/PluginData/Jool_movement.dds
+        swirlControlTexture    = MyMod/PluginData/Jool_swirl.dds
+
+        // Animation speeds (clamped at runtime)
+        bandMovementSpeed       = 0.05
+        swirlRotationSpeed      = 1
+        swirlRotationSwirliness = 1
+        swirlPanSpeed           = -0.05
+    }
+}
+```
+
+## How the layers combine
+
+The cloud bands are not a single painted texture — they are assembled at runtime:
+
+1. `cloudPatternMap` is sampled as a greyscale control map. Its **red** channel indexes the two colour ramps (`colorMap`, `colorMap2`), and its **green** channel blends between them. This is what gives a gas giant its characteristic two-tone band palette.
+2. `swirlControlTexture` and `movementControlTexture` distort and scroll the UV coordinates the patterns are read at, producing the slow swirling and east/west band drift.
+3. The `detail*` maps repeat this process at a finer scale (`detailTiling`) and are mixed in based on camera distance, so close-up views gain extra cloud structure.
+
+The movement itself is driven by the stock `GasGiantMaterialControls` component, which Kopernicus attaches to the scaled body automatically whenever this material is used. Every frame it writes the `_GasGiantTime` shader global and clamps the speed properties below to their valid ranges.
+
+Every texture also has matching `…Scale` and `…Offset` properties (a `Vector2` tiling/offset pair), omitted from the example for brevity.
+
+## Properties
+
+The properties fall into six groups, which we shall take in turn:
+
+1. **Far (base) layer** — the always-visible banding.
+2. **Detail (near) layer** — the high-frequency clouds that fade in up close.
+3. **Detail fade** — how that detail layer is mixed in by camera distance.
+4. **Animation control maps** — the textures that shape where bands sit and how they swirl.
+5. **Animation speeds** — the scalars that set how fast all of that moves.
+6. **Lighting and rim glow** — the specular response and the atmospheric halo at the limb.
+
+### Far (base) layer
+
+This is the layer you see from orbit: the broad bands that read at any distance. The pattern map is a control map rather than a picture — it tells the shader *which* of the two colour ramps to show at each point, and how to blend them.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `cloudPatternMap` | File Path | Far band pattern. **Red** channel = the band pattern; **green** channel = blend between `colorMap` and `colorMap2`. |
+| `cloudPatternMapScale` / `cloudPatternMapOffset` | Vector2 | Tiling and offset of the cloud pattern. |
+| `colorMap` | File Path | First far colour ramp, sampled by the pattern's red channel. Its alpha channel also contributes to surface smoothness. |
+| `colorMapScale` / `colorMapOffset` | Vector2 | Tiling and offset of the first colour ramp. |
+| `colorMap2` | File Path | Second far colour ramp, blended against `colorMap` by the pattern's green channel. |
+| `colorMap2Scale` / `colorMap2Offset` | Vector2 | Tiling and offset of the second colour ramp. |
+| `normalMap` | File Path | Far tangent-space normal map (DXT5nm), sampled at the same swirled UVs as the pattern. Also accepts the aliases `normals` and `bumpMap`. |
+| `normalMapScale` / `normalMapOffset` | Vector2 | Tiling and offset of the far normal map. |
+
+### Detail (near) layer
+
+The detail layer mirrors the far layer at a finer scale (set by `detailTiling`), adding cloud structure that is only worth showing when the camera is close. Its pattern is read more simply — only the red channel matters.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `detailCloudPatternMap` | File Path | High-frequency band pattern. Only the **red** channel is read. |
+| `detailCloudPatternMapScale` / `detailCloudPatternMapOffset` | Vector2 | Tiling and offset of the detail pattern. |
+| `detailColorMap` | File Path | Colour ramp for the detail layer, sampled by the detail pattern's red channel. |
+| `detailColorMapScale` / `detailColorMapOffset` | Vector2 | Tiling and offset of the detail colour ramp. |
+| `detailNormalMap` | File Path | Detail tangent-space normal map (DXT5nm). |
+| `detailNormalMapScale` / `detailNormalMapOffset` | Vector2 | Tiling and offset of the detail normal map. |
+| `detailTiling` | Decimal | UV multiplier applied to the far UVs to produce the detail UVs. Higher values give finer detail. Default 10. |
+
+### Detail fade (camera distance)
+
+A gas giant should reveal crisp cloud structure as you fly in, then melt back to smooth bands when viewed from orbit. These four properties describe that transition as a straight line: within `nearDetailDistance` the detail layer sits at full `nearDetailStrength`; beyond `farDetailDistance` it sits at `farDetailStrength`; between the two distances its strength is linearly interpolated.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `nearDetailDistance` | Decimal | Camera distance at or below which detail is at full `nearDetailStrength`. Default 50. |
+| `nearDetailStrength` | Decimal | Detail influence when zoomed in (at/below `nearDetailDistance`). `1` fully replaces the base layer; `0` hides detail. Default 0.8. |
+| `farDetailDistance` | Decimal | Camera distance at or beyond which detail is at full `farDetailStrength`. Default 200. |
+| `farDetailStrength` | Decimal | Detail influence when zoomed out (at/beyond `farDetailDistance`). Set `0` to make detail vanish at distance. Default 0. |
+
+### Animation control maps
+
+Where the speeds below say *how fast* the clouds move, these two textures say *where* and *how* they move. Both are static control maps whose individual channels each carry a different piece of the animation.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `movementControlTexture` | File Path | Static control map for band movement. **Red/green** drive left/right band movement (black = no movement, white = full speed, then scaled by `bandMovementSpeed`); **blue** blends between the two band reads; **alpha** controls swirl pan. Sampled without panning, so it defines where the bands permanently live. |
+| `movementControlTextureScale` / `movementControlTextureOffset` | Vector2 | Tiling and offset of the movement control map. |
+| `swirlControlTexture` | File Path | Control map shaping the swirls. **Red/green** = UV position of the centre of rotation; **blue** = swirl rotation amount. Sampled at a panned UV, so the swirl pattern itself drifts over time. |
+| `swirlControlTextureScale` / `swirlControlTextureOffset` | Vector2 | Tiling and offset of the swirl control map. |
+
+### Animation speeds
+
+These scalars set the pace of everything above. They are clamped to their valid ranges at runtime by `GasGiantMaterialControls`, so a value outside the listed range is simply pulled back to the nearest limit.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `bandMovementSpeed` | Decimal | East/west band scroll speed. Negative moves bands westward, positive eastward. Clamped to `[-10, 10]`. Default 0.05. |
+| `swirlRotationSpeed` | Decimal | How fast the swirl rotation evolves. Clamped to `[0, 10]`. Default 1. |
+| `swirlRotationSwirliness` | Decimal | Final angular scale of the swirl. Negative inverts the swirl direction; values near zero flatten the swirls to straight bands. Clamped to `[-10, 10]`. Default 1. |
+| `swirlPanSpeed` | Decimal | How fast the swirl control map drifts along the U axis. Clamped to `[-10, 10]`. Default -0.05. |
+
+### Lighting and rim glow
+
+Surface lighting uses a standard PBR specular workflow, and a view-angle rim emission produces the atmospheric halo around the planet's limb.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `specColor` | Color | Specular F0 colour for the PBR lighting. Also accepts the alias `specularColor`. Default (0.5, 0.5, 0.5, 1). |
+| `surfaceColorIntoEmissiveMultiplier` | Decimal | Fraction of the lit band colour bled into emission so the night side still glows faintly. `0` gives a pure dark night side. Range `[0, 1]`. Default 0.5. |
+| `rimPower` | Decimal | View-angle rim falloff exponent. Larger values concentrate the rim glow into a thinner ring at grazing angles. Default 3. |
+| `rimBlend` | Decimal | Multiplicative scale on the rim ramp colour — brightens or dims the whole rim glow. Default 1. |
+| `rimColorRamp` | File Path | 1D ramp tinting the rim emission, indexed by the day/night terminator so the rim is coloured differently on the lit and dark sides. |
+| `rimColorRampScale` / `rimColorRampOffset` | Vector2 | Tiling and offset of the rim colour ramp. |
+| `Gradient` | Gradient | The `rimColorRamp`, but defined explicitly as a gradient instead of a texture. Works the same way as the [atmospheric material's `Gradient`](/Syntax/ScaledVersion/Material): the left value is the position from 0 (lit side) to 1 (dark side), and the right value is the colour there. |
+
+```
+Material
+{
+    specColor = 0.5, 0.5, 0.5, 1
+    surfaceColorIntoEmissiveMultiplier = 0.5
+    rimPower = 3
+    rimBlend = 1
+    rimColorRamp = MyMod/PluginData/Jool_rim.dds
+}
+```
+
+The shader also has `_Opacity` and `_localLightDirection` properties, but they are marked `[PerRendererData]` and overwritten every frame by KSP's scaled-space lighting controller, so they are not exposed as config fields.
+
+## Notes
+
+* The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them.
+* Animation only runs in-game; the bands are static in the editor preview because `_GasGiantTime` is supplied at runtime.

--- a/docs/Syntax/Material/Scaled/GasGiant.md
+++ b/docs/Syntax/Material/Scaled/GasGiant.md
@@ -2,7 +2,7 @@
 
 **Shader:** `Terrain/Gas Giant` &nbsp;·&nbsp; **Runtime component:** `GasGiantMaterialControls`
 
-The Gas Giant `Material { }` drives the `Terrain/Gas Giant` shader — the animated, banded scaled-space surface used by Jool. Unlike the [Vacuum/Atmospheric materials](/Syntax/ScaledVersion/Material), which paint the planet from a single colour map, the gas giant builds its appearance procedurally from two **swirling cloud band layers**:
+The Gas Giant `Material { }` drives the `Terrain/Gas Giant` shader — the animated, banded scaled-space surface used by Jool. Unlike the [Vacuum](/Syntax/Material/Scaled/Vacuum) and [Atmospheric](/Syntax/Material/Scaled/Atmospheric) materials, which paint the planet from a single colour map, the gas giant builds its appearance procedurally from two **swirling cloud band layers**:
 
 * A **far (base) layer** that defines the overall banding and is visible at any distance.
 * A **detail (near) layer** of higher-frequency cloud structure that fades in as the camera approaches.

--- a/docs/Syntax/Material/Scaled/Star.md
+++ b/docs/Syntax/Material/Scaled/Star.md
@@ -1,0 +1,97 @@
+# Star Material
+
+**Shader:** `Emissive Multi Ramp Sunspots` &nbsp;·&nbsp; **Runtime component:** `SunShaderController`
+
+The Star `Material { }` drives the `Emissive Multi Ramp Sunspots` shader — the scaled-space surface used by stars. Unlike the [Vacuum](/Syntax/Material/Scaled/Vacuum), [Atmospheric](/Syntax/Material/Scaled/Atmospheric) and [Gas Giant](/Syntax/Material/Scaled/GasGiant) materials, which paint a planet's surface and *light* it with the local star, a star **is** the light source — so this shader is fundamentally **emissive** (self-illuminated) and **animated**. It builds a slowly boiling heat-map surface by scrolling a four-channel noise texture through a heat-colour ramp, darkens it inside a static **sunspot** mask, and finally washes the camera-facing face of the disc with a tint colour.
+
+In the stock system this material is used by the Sun (Kerbol) — the only star in the stock game.
+
+Selecting `type = Star` does more than pick a shader: it also tells Kopernicus that this body is a star. The body's [`ScaledVersion { }`](/Syntax/ScaledVersion) node then additionally accepts a `Light { }` block (a `LightShifter` controlling the star's lighting) and a `Coronas { }` collection (the flat corona billboards around the disc), and Kopernicus attaches the runtime components that make a star behave like one — the `SunShaderController` that animates this material, plus `ScaledSun` and `StarComponent`. Those star-wide pieces are out of scope here; this page documents only the surface material.
+
+We shall first see how to enable the material, then how the shader builds and animates the surface, and finally discuss each group of properties in turn.
+
+## Enabling
+
+Select the star material by setting `type = Star` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+
+```
+ScaledVersion
+{
+    type = Star
+    Material
+    {
+        // Animated heat-map surface
+        noiseMap   = MyMod/PluginData/Sun_noise.dds
+        emitColor0 = 0.6, 0.1, 0.0, 1   // colour where heat = 0 (cool)
+        emitColor1 = 1.0, 0.9, 0.4, 1   // colour where heat = 1 (hot)
+
+        // Sunspot overlay
+        sunspotTex   = MyMod/PluginData/Sun_sunspots.dds
+        sunspotColor = 0.2, 0.05, 0.0, 1
+        sunspotPower = 1
+
+        // Face-on colour wash (see note on "rim" naming below)
+        rimColor = 1, 1, 1, 1
+        rimPower = 0.2
+        rimBlend = 0.2
+    }
+}
+```
+
+## How the surface is built
+
+The shader is a self-illuminated surface assembled in three stages — there is no painted colour map and no atmospheric limb glow:
+
+1. **Animated heat map** — `noiseMap` is a four-channel scrolling noise texture. Each of its four channels is offset by its own runtime-driven scroll value and looked up in `rampMap`, a 1-D **heat ramp** read as a horizontal gradient from cool (left) to hot (right). The four lookups are averaged into a single `0..1` *heat* value per pixel, which then blends the surface colour between `emitColor0` (where heat is 0) and `emitColor1` (where heat is 1). Because the four channels scroll at different speeds, the heat pattern churns and never quite repeats — this is what gives a star its slow "boiling" motion.
+2. **Sunspots** — `sunspotTex` is a static greyscale mask. Its red channel, scaled by `sunspotPower`, blends the surface toward `sunspotColor` (a dark umbra colour), stamping cooler spots over the boiling emission. The mask is sampled at its own tiling, independent of the noise, so spots can be sized separately from the heat pattern.
+3. **Face-on colour wash** — finally the surface is blended toward `rimColor` by `saturate(N·V)^rimPower × rimBlend`, where `N·V` is how directly the surface faces the camera. **Despite the "rim" naming this is not a limb glow** — the term is strongest where the surface faces the camera head-on (the centre of the disc) and falls to zero at the silhouette, so `rimColor` tints the *centre* of the disc and the pure heat colours show through cleanest at the edge. This is the reverse of the limb-hugging rim on the [atmospheric](/Syntax/Material/Scaled/Atmospheric) shaders.
+
+The finished colour is emitted directly: a star lights itself and does not depend on an external sun. (It still has an ordinary Lambert lit term, so a star *can* be lit by another star, but in practice the emission dominates.)
+
+One important runtime detail: the `rampMap` you set in config is **regenerated and replaced at load** by the `SunShaderController` Kopernicus attaches to the star (see Notes). It is the same component that drives the scrolling offsets each frame. So of the maps below, `noiseMap` and `sunspotTex` are the two you author; `rampMap` is effectively controlled by the star component, not the material node.
+
+## Properties
+
+The properties fall into three groups, which we shall take in turn:
+
+1. **Heat-map surface** — the noise, the heat ramp, and the two emission colours it blends between.
+2. **Sunspots** — the overlay mask and the colour it stamps.
+3. **Face-on colour wash** — the camera-facing tint (named "rim" in the shader).
+
+### Heat-map surface
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `noiseMap` | File Path | Four-channel scrolling noise texture. Each channel is offset by its own runtime scroll value, looked up in `rampMap`, and the four results averaged into the per-pixel heat factor. Default "white". |
+| `noiseMapScale` / `noiseMapOffset` | Vector2 | Tiling and offset of the noise texture. |
+| `rampMap` | File Path | The 1-D heat colour ramp the noise is looked up in, read as a horizontal gradient from cool (left) to hot (right). **Overwritten at runtime** by the `SunShaderController` from its animation curves, so a config value has no lasting effect (see Notes). Default "white". |
+| `rampMapScale` / `rampMapOffset` | Vector2 | Tiling and offset of the ramp. |
+| `emitColor0` | Color | Emission colour where the heat factor is 0 (the cool end of the surface). Default (1, 1, 1, 1). |
+| `emitColor1` | Color | Emission colour where the heat factor is 1 (the hot end of the surface). Default (1, 1, 1, 1). |
+
+### Sunspots
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `sunspotTex` | File Path | Static sunspot mask; only the **red** channel is read. Multiplied by `sunspotPower` it gives the blend weight toward `sunspotColor`, so the mask should be **black where there are no spots**. Note the shader's own default of "white" reads as a full-strength spot everywhere, so a real star must supply this map. |
+| `sunspotTexScale` / `sunspotTexOffset` | Vector2 | Tiling and offset of the sunspot mask. |
+| `sunspotColor` | Color | The (typically dark, cool) colour the surface is blended toward inside the sunspot mask. Default (0, 0, 0, 0). |
+| `sunspotPower` | Decimal | Scalar multiplier on the sunspot mask's red channel before it is used as the blend weight. Values above 1 make spots more opaque; 0 disables the overlay. Default 1. |
+
+### Face-on colour wash
+
+The shader names these three properties "Rimlight", but as described above the effect tints the **camera-facing centre** of the disc and fades to nothing at the silhouette — it is not an atmospheric limb glow.
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `rimColor` | Color | Colour the surface is blended toward where it faces the camera head-on. With the default white it gently brightens the centre of the disc. Default (1, 1, 1, 1). |
+| `rimPower` | Decimal | Exponent applied to `saturate(N·V)`. Low values (the default) spread the wash broadly across the visible face; higher values pull it into a tighter spot at the very centre. Default 0.2. |
+| `rimBlend` | Decimal | Overall strength of the wash — the final blend weight toward `rimColor` is `saturate(N·V)^rimPower × rimBlend`. Set to 0 to disable it entirely. Default 0.2. |
+
+## Notes
+
+* The surface animation is driven by Kopernicus's `SunShaderController` component (a `SharedSunShaderController`, the shared-material variant of the stock class), which it attaches to every star automatically. Each frame it writes four scrolling offset globals that scroll the four `noiseMap` channels at different rates, producing the boiling motion.
+* That same component **regenerates `rampMap` at load**: it bakes a 256-pixel ramp texture from four animation curves and assigns it to the material, overwriting whatever `rampMap` the config set. The curves are not exposed through the `Material { }` node, so the heat ramp is effectively fixed by the star component rather than authored as a texture here.
+* Unlike the planet shaders, this material has **no `opacity` and no `localLightDirection`** — a star is not cross-faded to a local (PQS) representation, so Kopernicus does not attach the scaled-space fader to it, and the shader has no rim that tracks the Sun.
+* The shader uses the body's geometric normal directly and has **no normal map**, so it imposes no tangent requirement on the mesh.
+* If the shader fails to compile on the target platform it falls back to Unity's `Diffuse` shader.

--- a/docs/Syntax/Material/Scaled/Star.md
+++ b/docs/Syntax/Material/Scaled/Star.md
@@ -6,13 +6,13 @@ The Star `Material { }` drives the `Emissive Multi Ramp Sunspots` shader — the
 
 In the stock system this material is used by the Sun (Kerbol) — the only star in the stock game.
 
-Selecting `type = Star` does more than pick a shader: it also tells Kopernicus that this body is a star. The body's [`ScaledVersion { }`](/Syntax/ScaledVersion) node then additionally accepts a `Light { }` block (a `LightShifter` controlling the star's lighting) and a `Coronas { }` collection (the flat corona billboards around the disc), and Kopernicus attaches the runtime components that make a star behave like one — the `SunShaderController` that animates this material, plus `ScaledSun` and `StarComponent`. Those star-wide pieces are out of scope here; this page documents only the surface material.
+Selecting `type = Star` does more than pick a shader: it also tells Kopernicus that this body is a star. The body's [`ScaledVersion { }`](/Syntax/ScaledVersion/) node then additionally accepts a `Light { }` block (a `LightShifter` controlling the star's lighting) and a `Coronas { }` collection (the flat corona billboards around the disc), and Kopernicus attaches the runtime components that make a star behave like one — the `SunShaderController` that animates this material, plus `ScaledSun` and `StarComponent`. Those star-wide pieces are out of scope here; this page documents only the surface material.
 
 We shall first see how to enable the material, then how the shader builds and animates the surface, and finally discuss each group of properties in turn.
 
 ## Enabling
 
-Select the star material by setting `type = Star` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+Select the star material by setting `type = Star` in the [`ScaledVersion { }`](/Syntax/ScaledVersion/) node. The `Material { }` node then accepts the properties listed below.
 
 ```
 ScaledVersion

--- a/docs/Syntax/Material/Scaled/Vacuum.md
+++ b/docs/Syntax/Material/Scaled/Vacuum.md
@@ -1,0 +1,92 @@
+# Vacuum Material
+
+**Shader:** `Terrain/Scaled Planet (Simple)`
+
+The Vacuum `Material { }` drives the `Terrain/Scaled Planet (Simple)` shader — the plainest of the scaled-space planet shaders, and the type used by most airless bodies in the stock system. It paints the planet's distant, low-LOD sphere from a single **colour map** and lights it with a standard Blinn-Phong specular model.
+
+In the stock [KittopiaTech dumps](https://github.com/Kopernicus/kittopia-dumps), the bodies set to `type = Vacuum` are Moho, Gilly, the Mun, Minmus, Ike, Dres, Vall, Tylo, Bop, and Pol. It is not, however, used by *every* airless body: Eeloo has no atmosphere yet is set to `AtmosphericStandard`.
+
+It is the airless counterpart to the [Atmospheric material](/Syntax/Material/Scaled/Atmospheric): both build the surface the same way, but the atmospheric shader (`Terrain/Scaled Planet (RimAerial)`) adds a view-angle rim glow for the atmosphere's limb, whereas this one has no rim at all. If your body builds its appearance procedurally from cloud bands instead of a painted map, see the [Gas Giant material](/Syntax/Material/Scaled/GasGiant).
+
+We shall first see how to enable the material, then how the shader lights the surface, and finally discuss each group of properties in turn.
+
+## Enabling
+
+Select the vacuum material by setting `type = Vacuum` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+
+```
+ScaledVersion
+{
+    type = Vacuum
+    Material
+    {
+        // Surface maps
+        texture = MyMod/PluginData/Mun_color.dds
+        normals = MyMod/PluginData/Mun_normal.dds
+
+        // Colour and specular response
+        color     = 1, 1, 1, 1
+        specColor = 0.5, 0.5, 0.5, 1
+        shininess = 0.078125
+
+        // Resource-scanner overlay (optional)
+        resourceMap = MyMod/PluginData/Mun_resources.dds
+    }
+}
+```
+
+## How the surface is lit
+
+The vacuum shader is essentially Unity's BumpedSpecular (Blinn-Phong) lighting with three KSP-specific pieces layered on top:
+
+1. **Colour and gloss** — `texture` is the colour map. Its **RGB** channels are the surface albedo (multiplied by `color`), and its **alpha** channel is a per-pixel *specular intensity mask*: bright areas catch the sun's highlight strongly, dark areas stay matte. This lets a single texture vary glossiness across the surface (e.g. shiny crater glass against dull regolith).
+2. **Surface relief** — `normals` is a tangent-space normal map that perturbs the lighting per pixel, so the body keeps fine surface detail when viewed from orbit even though the scaled-space mesh is smooth.
+3. **Resource overlay** — `resourceMap` is the resource-scanner overlay. It is composited additively (`rgb × a`) on top of the lit surface, so the default all-black map contributes nothing and it only shows once a scan reveals it.
+
+The highlight itself is shaped by `specColor` (its tint) and `shininess` (how tight it is). There is no atmosphere, emission, or rim term — what you paint is what you get, lit by the local star.
+
+## Properties
+
+The properties fall into four groups, which we shall take in turn:
+
+1. **Surface maps** — the colour and normal textures that define the body's appearance.
+2. **Colour and specular** — the tints and highlight sharpness applied during lighting.
+3. **Resource overlay** — the optional scanner map composited on top.
+4. **Opacity** — the scaled-space fade scalar.
+
+### Surface maps
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `texture` | File Path | The scaled-space colour map. **RGB** = surface albedo (multiplied by `color`); **alpha** = per-pixel specular intensity mask. Also accepts the alias `mainTex`. Default "white". |
+| `mainTexScale` / `mainTexOffset` | Vector2 | Tiling and offset of the colour map. |
+| `normals` | File Path | Tangent-space normal map, stored in DXT5nm packing (X in the alpha channel, Y in green, Z reconstructed). Also accepts the alias `bumpMap`. Default "bump" (flat). |
+| `bumpMapScale` / `bumpMapOffset` | Vector2 | Tiling and offset of the normal map. |
+
+### Colour and specular
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `color` | Color | Master diffuse tint multiplied into the colour map's RGB before lighting. The alpha is unused. Default (1, 1, 1, 1). |
+| `specColor` | Color | Specular highlight tint, scaled by the star's light colour and further modulated by the colour map's alpha mask. Set to black to disable specular entirely. Default (0.5, 0.5, 0.5, 1). |
+| `shininess` | Decimal | Highlight sharpness. The value maps to a Blinn-Phong specular exponent of `shininess × 128` — smaller values give a broad, soft highlight, larger values a tight, sharp one. The shader declares the valid range as `[0.03, 1]`. Default 0.078125. |
+
+### Resource overlay
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `resourceMap` | File Path | Resource-scanner overlay texture, composited additively as `rgb × a` over the lit surface. Default "black" (contributes nothing). |
+| `resourceMapScale` / `resourceMapOffset` | Vector2 | Tiling and offset of the resource map. |
+
+### Opacity
+
+| Property | Format | Description |
+|----------|--------|-------------|
+| `opacity` | Decimal | Master opacity of the scaled-space material, range `[0, 1]`. Default 1. |
+
+## Notes
+
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which cross-fades the body between its scaled-space and local (PQS) representations as the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes. A static config value is therefore normally left at its default of 1.
+* `resourceMap` is likewise `[PerRendererData]`: KSP's surface-resource visualisation layer sets it per-renderer when a scan is active. The default black texture means no overlay is shown.
+* The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.
+* If the shader fails to compile on the target platform it falls back to Unity's `Standard` shader.

--- a/docs/Syntax/Material/Scaled/Vacuum.md
+++ b/docs/Syntax/Material/Scaled/Vacuum.md
@@ -12,7 +12,7 @@ We shall first see how to enable the material, then how the shader lights the su
 
 ## Enabling
 
-Select the vacuum material by setting `type = Vacuum` in the [`ScaledVersion { }`](/Syntax/ScaledVersion) node. The `Material { }` node then accepts the properties listed below.
+Select the vacuum material by setting `type = Vacuum` in the [`ScaledVersion { }`](/Syntax/ScaledVersion/) node. The `Material { }` node then accepts the properties listed below.
 
 ```
 ScaledVersion
@@ -86,7 +86,7 @@ The properties fall into four groups, which we shall take in turn:
 
 ## Notes
 
-* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which cross-fades the body between its scaled-space and local (PQS) representations as the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion) altitudes. A static config value is therefore normally left at its default of 1.
+* `opacity` is marked `[PerRendererData]` and is driven at runtime by the scaled-space fader, which cross-fades the body between its scaled-space and local (PQS) representations as the camera crosses the [`fadeStart` and `fadeEnd`](/Syntax/ScaledVersion/) altitudes. A static config value is therefore normally left at its default of 1.
 * `resourceMap` is likewise `[PerRendererData]`: KSP's surface-resource visualisation layer sets it per-renderer when a scan is active. The default black texture means no overlay is shown.
 * The shader requires mesh **tangents** for its normal mapping — the scaled mesh Kopernicus generates already provides them. A custom mesh without tangents will render with broken normals.
 * If the shader fails to compile on the target platform it falls back to Unity's `Standard` shader.

--- a/docs/Syntax/ScaledVersion/index.md
+++ b/docs/Syntax/ScaledVersion/index.md
@@ -3,10 +3,20 @@
 The `ScaledVersion { }` node in a configuration file for Kopernicus describes a less-detailed model of your planet that appears in the map view and from large distances.
 
 ## Subnodes
-* [Material { }](/Syntax/ScaledVersion/Material) = Updates to textures and atmosphere rims.
 * [OnDemand { }](/Syntax/ScaledVersion/OnDemand) = Used for textures that should be loaded OnDemand.
 * [Light { }](/Syntax/ScaledVersion/Light) = Used for making stars.
 * [Coronas { }](/Syntax/ScaledVersion/Corona) = Used for making stars.
+
+## Material
+There are a number of different materials KSP provides for scaled space bodies. These control how the scaled space model of the body looks and each corresponds to a different shader. You can choose among the materials that KSP provides by using the `type` property, or you can explicitly set `shader = X` to override the shader.
+
+The types you can use are:
+- [`Vacuum`](./../Material/Scaled/Vacuum.md)
+- [`Atmospheric`](./../Material/Scaled/Atmospheric.md)
+- [`AtmosphericStandard`](./../Material/Scaled/AtmosphericStandard.md)
+- [`GasGiant`](./../Material/Scaled/GasGiant.md)
+- [`Star`](./../Material/Scaled/Star.md)
+- `Custom` - this one needs you to provide your own shader.
 
 ## Example
 ```


### PR DESCRIPTION
I have recently finished decompiling all the KSP1 shaders, so now I can use that to actually produce useful documentation for them. This PR covers all the shaders available via `ScaledVersion`.